### PR TITLE
New methods

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -75,11 +75,6 @@ func (c *Collection) StateCount(state State) int {
 	return n
 }
 
-// IsUp returns true if all the monitored services are ready.
-func (c *Collection) IsUp() bool {
-	return c.GetState() == Ready
-}
-
 // UpDown returns two slices, one containing the labels of monitored services
 // Returns nil if all services are ready.
 func (c *Collection) Up() map[string]bool {

--- a/collection.go
+++ b/collection.go
@@ -75,8 +75,8 @@ func (c *Collection) StateCount(state State) int {
 	return n
 }
 
-// Up returns a map containing the labels of all the currently monitored services and an indication of whether each is
-// in the ready state (true) or not (false).
+// Up returns a map whose keys are the labels of all the currently monitored services and whose values are true if
+// the service is ready and false otherwise.
 func (c *Collection) Up() map[string]bool {
 	up := make(map[string]bool)
 	c.Lock()

--- a/collection.go
+++ b/collection.go
@@ -75,8 +75,8 @@ func (c *Collection) StateCount(state State) int {
 	return n
 }
 
-// UpDown returns two slices, one containing the labels of monitored services
-// Returns nil if all services are ready.
+// Up returns a map containing the labels of all the currently monitored services and an indication of whether each is
+// in the ready state (true) or not (false).
 func (c *Collection) Up() map[string]bool {
 	up := make(map[string]bool)
 	c.Lock()

--- a/collection_test.go
+++ b/collection_test.go
@@ -15,7 +15,6 @@ func TestCollection(t *testing.T) {
 	assertEqual(t, NotReady, s)
 	assertEqual(t, nil, e)
 	assertEqual(t, s, co.GetState())
-	assertEqual(t, false, co.IsUp())
 	assertEqual(t, map[string]bool{}, co.Up())
 
 	// Add services.
@@ -27,7 +26,6 @@ func TestCollection(t *testing.T) {
 	assertEqual(t, NotReady, s)
 	assertEqual(t, nil, e)
 	assertEqual(t, s, co.GetState())
-	assertEqual(t, false, co.IsUp())
 	assertEqual(t, map[string]bool{"service 0": false, "service 1": false}, co.Up())
 
 	// One service is ready.
@@ -37,7 +35,6 @@ func TestCollection(t *testing.T) {
 	assertEqual(t, NotReady, s)
 	assertEqual(t, nil, e)
 	assertEqual(t, s, co.GetState())
-	assertEqual(t, false, co.IsUp())
 	assertEqual(t, map[string]bool{"service 0": true, "service 1": false}, co.Up())
 
 	// Both services are ready.
@@ -47,7 +44,6 @@ func TestCollection(t *testing.T) {
 	assertEqual(t, Ready, s)
 	assertEqual(t, nil, e)
 	assertEqual(t, s, co.GetState())
-	assertEqual(t, true, co.IsUp())
 	assertEqual(t, map[string]bool{"service 0": true, "service 1": true}, co.Up())
 
 	assertEqual(t, 2, co.StateCount(Ready))
@@ -61,7 +57,6 @@ func TestCollection(t *testing.T) {
 	assertEqual(t, Stopped, s)
 	assertEqual(t, nil, e)
 	assertEqual(t, s, co.GetState())
-	assertEqual(t, false, co.IsUp())
 	assertEqual(t, map[string]bool{"service 0": false, "service 1": true}, co.Up())
 
 	assertEqual(t, 1, co.StateCount(Ready))
@@ -75,14 +70,12 @@ func TestCollection(t *testing.T) {
 	assertEqual(t, Stopped, s)
 	assertEqual(t, nil, e)
 	assertEqual(t, s, co.GetState())
-	assertEqual(t, false, co.IsUp())
 	assertEqual(t, map[string]bool{"service 0": false, "service 1": false}, co.Up())
 
 	// Stop all services.
 	co.Stop()
 	assertEqual(t, 0, co.StateCount(Ready))
 	assertEqual(t, 0, co.StateCount(NotReady))
-	assertEqual(t, false, co.IsUp())
 	assertEqual(t, map[string]bool{}, co.Up())
 
 	// We also have no stopped services because the service list has been emptied.
@@ -109,6 +102,5 @@ func TestCollection2(t *testing.T) {
 	assertEqual(t, NotReady, s)
 	assertEqual(t, nil, e)
 	assertEqual(t, s, co.GetState())
-	assertEqual(t, false, co.IsUp())
 	assertEqual(t, map[string]bool{"service 0": true, "service 1": false}, co.Up())
 }

--- a/collection_test.go
+++ b/collection_test.go
@@ -1,6 +1,7 @@
 package nested
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
@@ -10,32 +11,44 @@ func TestCollection(t *testing.T) {
 	co := Collection{}
 
 	// A new collection is not ready.
-	s, e := co.GetState()
+	s, e := co.GetFullState()
 	assertEqual(t, NotReady, s)
 	assertEqual(t, nil, e)
+	assertEqual(t, s, co.GetState())
+	assertEqual(t, false, co.IsUp())
+	assertEqual(t, map[string]bool{}, co.Up())
 
 	// Add services.
 	s0, s1 := &Monitor{}, &Monitor{}
-	co.Add(s0)
-	co.Add(s1)
+	co.Add("service 0", s0)
+	co.Add("service 1", s1)
 	time.Sleep(10 * time.Millisecond)
-	s, e = co.GetState()
+	s, e = co.GetFullState()
 	assertEqual(t, NotReady, s)
 	assertEqual(t, nil, e)
+	assertEqual(t, s, co.GetState())
+	assertEqual(t, false, co.IsUp())
+	assertEqual(t, map[string]bool{"service 0": false, "service 1": false}, co.Up())
 
 	// One service is ready.
 	s0.SetState(Ready, nil)
 	time.Sleep(10 * time.Millisecond)
-	s, e = co.GetState()
+	s, e = co.GetFullState()
 	assertEqual(t, NotReady, s)
 	assertEqual(t, nil, e)
+	assertEqual(t, s, co.GetState())
+	assertEqual(t, false, co.IsUp())
+	assertEqual(t, map[string]bool{"service 0": true, "service 1": false}, co.Up())
 
 	// Both services are ready.
 	s1.SetState(Ready, nil)
 	time.Sleep(10 * time.Millisecond)
-	s, e = co.GetState()
+	s, e = co.GetFullState()
 	assertEqual(t, Ready, s)
 	assertEqual(t, nil, e)
+	assertEqual(t, s, co.GetState())
+	assertEqual(t, true, co.IsUp())
+	assertEqual(t, map[string]bool{"service 0": true, "service 1": true}, co.Up())
 
 	assertEqual(t, 2, co.StateCount(Ready))
 	assertEqual(t, 0, co.StateCount(NotReady))
@@ -44,9 +57,12 @@ func TestCollection(t *testing.T) {
 	// One service is stopped.
 	s0.Stop()
 	time.Sleep(10 * time.Millisecond)
-	s, e = co.GetState()
+	s, e = co.GetFullState()
 	assertEqual(t, Stopped, s)
 	assertEqual(t, nil, e)
+	assertEqual(t, s, co.GetState())
+	assertEqual(t, false, co.IsUp())
+	assertEqual(t, map[string]bool{"service 0": false, "service 1": true}, co.Up())
 
 	assertEqual(t, 1, co.StateCount(Ready))
 	assertEqual(t, 0, co.StateCount(NotReady))
@@ -55,15 +71,44 @@ func TestCollection(t *testing.T) {
 	// One service is stopped, and the other is not ready.
 	s1.SetState(NotReady, nil)
 	time.Sleep(10 * time.Millisecond)
-	s, e = co.GetState()
+	s, e = co.GetFullState()
 	assertEqual(t, Stopped, s)
 	assertEqual(t, nil, e)
+	assertEqual(t, s, co.GetState())
+	assertEqual(t, false, co.IsUp())
+	assertEqual(t, map[string]bool{"service 0": false, "service 1": false}, co.Up())
 
 	// Stop all services.
 	co.Stop()
 	assertEqual(t, 0, co.StateCount(Ready))
 	assertEqual(t, 0, co.StateCount(NotReady))
+	assertEqual(t, false, co.IsUp())
+	assertEqual(t, map[string]bool{}, co.Up())
 
 	// We also have no stopped services because the service list has been emptied.
 	assertEqual(t, 0, co.StateCount(Stopped))
+}
+
+func TestCollection2(t *testing.T) {
+
+	co := Collection{}
+
+	// A new collection is not ready.
+	s, e := co.GetFullState()
+	assertEqual(t, NotReady, s)
+	assertEqual(t, nil, e)
+
+	// Add two services; one is ready, one isn't.
+	s0, s1 := &Monitor{}, &Monitor{}
+	s0.SetState(Ready, nil)
+	co.Add("service 0", s0)
+	s1.SetState(NotReady, errors.New("oh, no!"))
+	co.Add("service 1", s1)
+	time.Sleep(10 * time.Millisecond)
+	s, e = co.GetFullState()
+	assertEqual(t, NotReady, s)
+	assertEqual(t, nil, e)
+	assertEqual(t, s, co.GetState())
+	assertEqual(t, false, co.IsUp())
+	assertEqual(t, map[string]bool{"service 0": true, "service 1": false}, co.Up())
 }

--- a/monitor.go
+++ b/monitor.go
@@ -21,7 +21,14 @@ type Monitor struct {
 var _ Service = &Monitor{}
 
 // GetState returns the current state of the service.
-func (m *Monitor) GetState() (State, error) {
+func (m *Monitor) GetState() State {
+	m.Lock()
+	defer m.Unlock()
+	return m.state
+}
+
+// GetFullState returns the current state and error state of the service.
+func (m *Monitor) GetFullState() (State, error) {
 	m.Lock()
 	defer m.Unlock()
 	return m.state, m.err

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -37,20 +37,20 @@ func TestMonitor(t *testing.T) {
 
 	// A new Monitor is not ready.
 	mon := Monitor{}
-	s, e := mon.GetState()
+	s, e := mon.GetFullState()
 	assertEqual(t, NotReady, s)
 	assertEqual(t, nil, e)
 
 	// Set to ready.
 	mon.SetState(Ready, nil)
-	s, e = mon.GetState()
+	s, e = mon.GetFullState()
 	assertEqual(t, Ready, s)
 	assertEqual(t, nil, e)
 
 	// Set to not ready with a reason.
 	reason := errors.New("some reason")
 	mon.SetState(NotReady, reason)
-	s, e = mon.GetState()
+	s, e = mon.GetFullState()
 	assertEqual(t, NotReady, s)
 	assertEqual(t, reason, e)
 
@@ -59,13 +59,13 @@ func TestMonitor(t *testing.T) {
 
 	// Set ready again.
 	mon.SetState(Ready, nil)
-	s, e = mon.GetState()
+	s, e = mon.GetFullState()
 	assertEqual(t, Ready, s)
 	assertEqual(t, nil, e)
 
 	// Stop.
 	mon.Stop()
-	s, e = mon.GetState()
+	s, e = mon.GetFullState()
 	assertEqual(t, Stopped, s)
 	assertEqual(t, nil, e)
 
@@ -80,13 +80,13 @@ func TestMonitor2(t *testing.T) {
 	// Failure on initialization.
 	failure := errors.New("some failure")
 	mon.SetState(Stopped, failure)
-	s, e := mon.GetState()
+	s, e := mon.GetFullState()
 	assertEqual(t, Stopped, s)
 	assertEqual(t, failure, e)
 
 	// Now Stop() should be a no-op
 	mon.Stop()
-	s, e = mon.GetState()
+	s, e = mon.GetFullState()
 	assertEqual(t, Stopped, s)
 	assertEqual(t, failure, e) // note that the error condition is still there
 }

--- a/nested.go
+++ b/nested.go
@@ -19,8 +19,10 @@ func (s State) String() string {
 }
 
 type Service interface {
-	// GetState returns the current state and error state of the service.
-	GetState() (State, error)
+	// GetState returns the current state of the service.
+	GetState() State
+	// GetFullState returns the current state and error state of the service.
+	GetFullState() (State, error)
 	// Stop stops the service, and releases all resources.  After sending the final update to the stopped state,
 	// all subscriptions are unsubscribed.  Future calls to GetState() will always return Stopped.
 	Stop()


### PR DESCRIPTION
Some improvements to the API:

- Renames `GetState()` to `GetFullState()`.  Introduces a new `GetState()` that returns only the state value (without the error state), eliminating the need for the `if s, _ := x.GetState(); s == Ready` pattern.
- Adds a `label` parameter to `Collection.Add()`, so that services in the collection can be referenced.
- Adds the method `Collection.Up()` to return a map indicating the readiness of all currently monitored services.