### PR TITLE
Simplify callbacks

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -3,9 +3,7 @@ package nested
 import (
 	"errors"
 	"fmt"
-	"math/rand"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 )
@@ -30,7 +28,6 @@ type Collection struct {
 	sync.Mutex
 	services map[string]Service
 	running  bool
-	id       string // random id to distinguish this from other collections when registering observers
 }
 
 // Verifies that a Collection implements the Service interface.
@@ -65,7 +62,6 @@ func (c *Collection) Add(label string, s Service) {
 	// Initialize the maps if this is the first service to be added.
 	if c.services == nil {
 		c.services = make(map[string]Service)
-		c.id = strconv.FormatUint(rand.Uint64(), 16)
 	} else {
 		// Otherwise check that we're not reusing a label.
 		if _, ok := c.services[label]; ok {
@@ -78,7 +74,7 @@ func (c *Collection) Add(label string, s Service) {
 	// Just in case someone adds a service to a running collection, make sure we get its events.  The alternative would
 	// be to disallow adding the service in the first place, but we don't want to do that.
 	if c.running {
-		s.RegisterCallback(c.id, c.stateChanged)
+		s.RegisterCallback(c.stateChanged)
 	}
 }
 
@@ -91,7 +87,7 @@ func (c *Collection) Run() {
 	c.Lock()
 	defer c.Unlock()
 	for _, s := range c.services {
-		s.RegisterCallback(c.id, c.stateChanged)
+		s.RegisterCallback(c.stateChanged)
 	}
 }
 

--- a/monitor.go
+++ b/monitor.go
@@ -47,7 +47,14 @@ func (m *Monitor) RegisterCallback(f func(Event)) Token {
 	if m.callbacks == nil {
 		m.callbacks = make(map[Token]func(Event))
 	}
-	token := Token(rand.Uint64())
+
+	// Choose a random token that we haven't used.
+	var token Token
+	for ok := true; ok; {
+		token = Token(rand.Uint32())
+		_, ok = m.callbacks[token]
+	}
+
 	m.callbacks[token] = f
 	return token
 }

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -69,7 +69,7 @@ func TestMonitorNotifications(t *testing.T) {
 
 	mon := Monitor{}
 	ch := make(chan Event, 1)
-	mon.RegisterCallback("foo", func(ev Event) { ch <- ev })
+	mon.RegisterCallback(func(ev Event) { ch <- ev })
 
 	// Set to Ready.
 	mon.SetReady()
@@ -120,10 +120,7 @@ func TestDeregister(t *testing.T) {
 	mon := Monitor{}
 	ch := make(chan Event, 1)
 
-	// Deregistering something that doesn't exist is not an error.
-	mon.DeregisterCallback("foo")
-
-	mon.RegisterCallback("foo", func(ev Event) { ch <- ev })
+	foo := mon.RegisterCallback(func(ev Event) { ch <- ev })
 
 	// Set to ready.
 	mon.SetReady()
@@ -132,13 +129,16 @@ func TestDeregister(t *testing.T) {
 	assertEqual(t, n.NewState, Ready)
 	assertEqual(t, n.Error, nil)
 
-	mon.DeregisterCallback("foo")
+	mon.DeregisterCallback(foo)
 
 	// No more notifications.
 	mon.Stop()
 	if len(ch) > 0 {
 		t.Error("unexpected notification")
 	}
+
+	// Deregistering again is not an error
+	mon.DeregisterCallback(foo)
 
 	close(ch)
 }

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -68,8 +68,8 @@ func TestMonitor(t *testing.T) {
 func TestMonitorNotifications(t *testing.T) {
 
 	mon := Monitor{}
-	ch := make(testObserver, 1)
-	mon.Register(ch)
+	ch := make(chan Event, 1)
+	mon.RegisterCallback("foo", func(ev Event) { ch <- ev })
 
 	// Set to Ready.
 	mon.SetReady()
@@ -118,12 +118,12 @@ func TestMonitorNotifications(t *testing.T) {
 func TestDeregister(t *testing.T) {
 
 	mon := Monitor{}
-	ch := make(testObserver, 1)
+	ch := make(chan Event, 1)
 
 	// Deregistering something that doesn't exist is not an error.
-	mon.Deregister(ch)
+	mon.DeregisterCallback("foo")
 
-	mon.Register(ch)
+	mon.RegisterCallback("foo", func(ev Event) { ch <- ev })
 
 	// Set to ready.
 	mon.SetReady()
@@ -132,7 +132,7 @@ func TestDeregister(t *testing.T) {
 	assertEqual(t, n.NewState, Ready)
 	assertEqual(t, n.Error, nil)
 
-	mon.Deregister(ch)
+	mon.DeregisterCallback("foo")
 
 	// No more notifications.
 	mon.Stop()
@@ -142,7 +142,3 @@ func TestDeregister(t *testing.T) {
 
 	close(ch)
 }
-
-type testObserver chan Event
-
-func (ch testObserver) OnNotify(ev Event) { ch <- ev }

--- a/nested.go
+++ b/nested.go
@@ -35,9 +35,12 @@ type Service interface {
 	Err() error
 	// Stop stops the service and releases all resources.  Stop should not return until the service shutdown is complete.
 	Stop()
-	// RegisterCallback registers a function which will be called any time there is a state change.  Replaces any
-	// existing callback registered with the provided id.
-	RegisterCallback(id string, f func(Event))
-	// Deregister removes a registered callback.  Does nothing if there is no observer registered with the provided id.
-	DeregisterCallback(id string)
+	// RegisterCallback registers a function which will be called any time there is a state change.  Returns a token
+	// that can be used to deregister it later.
+	RegisterCallback(f func(Event)) Token
+	// Deregister removes a registered callback.  Does nothing if there is no callback registered with the provided token.
+	DeregisterCallback(Token)
 }
+
+// A Token identifies a registered callback so that it can later be deregistered.
+type Token uint64

--- a/nested.go
+++ b/nested.go
@@ -43,4 +43,4 @@ type Service interface {
 }
 
 // A Token identifies a registered callback so that it can later be deregistered.
-type Token uint64
+type Token uint32

--- a/nested.go
+++ b/nested.go
@@ -27,11 +27,6 @@ type Event struct {
 	Error    error // error condition if the new state is Error, nil otherwise
 }
 
-// An observer receives notifications of state changes.
-type Observer interface {
-	OnNotify(Event)
-}
-
 // The Service interface defines the behavior of a nested service.
 type Service interface {
 	// GetState returns the current state of the service.
@@ -40,9 +35,9 @@ type Service interface {
 	Err() error
 	// Stop stops the service and releases all resources.  Stop should not return until the service shutdown is complete.
 	Stop()
-	// Register registers an observer, whose OnNotify method will be called any time there is a state change.  Does
-	// nothing if the observer is already registered.
-	Register(Observer)
-	// Deregister removes a registered observer.  Does nothing if the observer is not registered.
-	Deregister(Observer)
+	// RegisterCallback registers a function which will be called any time there is a state change.  Replaces any
+	// existing callback registered with the provided id.
+	RegisterCallback(id string, f func(Event))
+	// Deregister removes a registered callback.  Does nothing if there is no observer registered with the provided id.
+	DeregisterCallback(id string)
 }


### PR DESCRIPTION
Simplifies the registering of callback functions, fixing an issue where a non-comparable observer would cause a runtime panic when added to the observer map.
