### PR TITLE
Add SetReadyOrError

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,7 @@ orbs:
 executors:
   golang-executor:
     docker:
-    - image: cimg/go:1.19
-    environment:
-      GO111MODULE: "on"
+    - image: cimg/go:1.25
 
 workflows:
   build_and_test:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/travelaudience/go-nested
 
-go 1.19
+go 1.25

--- a/monitor.go
+++ b/monitor.go
@@ -82,10 +82,20 @@ func (m *Monitor) SetReady() {
 	m.setState(Ready, nil)
 }
 
-// SetReady sets the monitor state to Error.  If there are registered observers, all observers are called before returning.
+// SetError sets the monitor state to Error.  If there are registered observers, all observers are called before returning.
 // Panics if the monitor is already stopped.
 func (m *Monitor) SetError(err error) {
 	m.setState(Error, err)
+}
+
+// SetReadyOrError sets the monitor state to Ready if err is nil or Error if err is non-nil.  If there are registered
+// observers, all observers are called before returning.  Panics if the monitor is already stopped.
+func (m *Monitor) SetReadyOrError(err error) {
+	if err == nil {
+		m.setState(Ready, nil)
+	} else {
+		m.setState(Error, err)
+	}
 }
 
 func (m *Monitor) setState(newState State, newErr error) {

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -55,13 +55,13 @@ func TestMonitor(t *testing.T) {
 	assertEqual(t, 1, mon.ErrCount())
 
 	// Two consecutive errors.
-	mon.SetError(reason)
+	mon.SetReadyOrError(reason)
 	assertEqual(t, Error, mon.GetState())
 	assertEqual(t, reason, mon.Err())
 	assertEqual(t, 2, mon.ErrCount())
 
 	// Set Ready again.  Previous error can still be retrieved.
-	mon.SetReady()
+	mon.SetReadyOrError(nil)
 	assertEqual(t, Ready, mon.GetState())
 	assertEqual(t, reason, mon.Err())
 	assertEqual(t, 0, mon.ErrCount())


### PR DESCRIPTION
Adds a convenience function `SetReadyOrError` so that we don't need to repeat this condition all over the place.

```
if err == nil {
    m.SetReady()
} else {
    m.SetError(err)
}
```

- [x] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
